### PR TITLE
Add symbolic links to correctors data (id-sabia) and README.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+feedforward-correctors/measurement
+measurement
+TEST

--- a/feedforward-correctors/README.txt
+++ b/feedforward-correctors/README.txt
@@ -1,0 +1,1 @@
+Rotcoil measurements are in id-sabia/feedforward-correctors/model-03/measurement/magnetic/rotcoil

--- a/measurement/.gitignore
+++ b/measurement/.gitignore
@@ -1,0 +1,1 @@
+feedforward-correctors/measurement


### PR DESCRIPTION
- `feedforward-correctors/measurement` in `.gitignore`is a local symbolic link for easy access to EPU correctors data.
- README.txt added explaining where the corrector data is located.